### PR TITLE
Fix script interpreter

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -euf -o pipefail
 


### PR DESCRIPTION
When you want to utilise Bash shell options like '-o pipefail' you need to set the Bash shell as the interpreter.